### PR TITLE
Align replacement flow UI with first issuance

### DIFF
--- a/src/main/webapp/buy-replacement.xhtml
+++ b/src/main/webapp/buy-replacement.xhtml
@@ -10,8 +10,8 @@
     </f:metadata>
     <ui:define name="title">Replacement PINs – Veristore</ui:define>
     <ui:define name="content">
-        <div class="row g-5 align-items-start">
-            <div class="col-12 col-xl-7 col-xxl-8">
+        <div class="row justify-content-center g-5">
+            <div class="col-12 col-xl-10 col-xxl-8">
                 <h:form id="purchaseForm" prependId="true" styleClass="d-flex flex-column gap-4">
                     <h:messages id="messages"
                                 globalOnly="true"
@@ -20,10 +20,10 @@
                                 errorClass="alert-danger"
                                 infoClass="alert-info" />
 
-                    <div class="card shadow-sm">
+                    <div class="product-detail-card">
                         <div class="card-body">
-                            <h2 class="h5 fw-semibold mb-3">Step 1 · Choose applicant category</h2>
-                            <p class="text-muted mb-4">Need a replacement PIN? Start by selecting the applicant’s citizenship group to reveal eligible packages.</p>
+                            <h2 class="h4 fw-semibold mb-3">Step 1 · Choose applicant category</h2>
+                            <p class="text-muted mb-4">Need a replacement PIN? Start by selecting the applicant’s citizenship group to unlock matching packages.</p>
                             <h:selectOneMenu id="citizenship"
                                              value="#{purchaseView.citizenship}"
                                              styleClass="d-none">
@@ -33,143 +33,171 @@
                                                itemValue="#{cit}"
                                                itemLabel="#{purchaseView.labelForCitizenship(cit)}" />
                             </h:selectOneMenu>
-                            <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-3">
-                                <ui:repeat value="#{purchaseView.citizenshipsForApp}" var="cit">
-                                    <div class="col">
-                                        <div class="selectable-card h-100 #{purchaseView.isCitizenshipSelected(cit) ? 'selected' : ''}">
-                                            <div class="card-body">
-                                                <h3 class="h6 fw-semibold mb-1">#{purchaseView.labelForCitizenship(cit)}</h3>
-                                                <p class="text-muted small mb-0">#{purchaseView.describeCitizenshipOption(cit)}</p>
-                                                <h:commandLink action="#{purchaseView.selectCitizenship(cit)}"
-                                                              styleClass="stretched-link"
-                                                              value=""
-                                                              title="Choose #{purchaseView.labelForCitizenship(cit)}">
-                                                    <f:ajax execute="@this"
-                                                            render="purchaseForm:citizenship purchaseForm:tierSection purchaseForm:variantSection purchaseForm:variant purchaseForm:totalCard purchaseForm:reviewButton purchaseForm:messages" />
-                                                </h:commandLink>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </ui:repeat>
-                            </div>
-                            <h:message for="citizenship" styleClass="text-danger small mt-2 d-block" />
-                        </div>
-                    </div>
-
-                    <h:panelGroup id="tierSection" layout="block" rendered="#{purchaseView.isTierRequired()}">
-                        <div class="card shadow-sm">
-                            <div class="card-body">
-                                <h2 class="h5 fw-semibold mb-3">Step 2 · Select service tier</h2>
-                                <p class="text-muted mb-4">Citizen replacements support both Standard and Premium tiers.</p>
-                                <h:selectOneMenu id="tier"
-                                                 value="#{purchaseView.citizenTier}"
-                                                 styleClass="d-none"
-                                                 rendered="#{purchaseView.isTierRequired()}">
-                                    <f:selectItem itemLabel="" itemValue="" noSelectionOption="true" />
-                                    <f:selectItems value="#{purchaseView.tiersForCitizen}"
-                                                   var="tierOpt"
-                                                   itemValue="#{tierOpt}"
-                                                   itemLabel="#{purchaseView.labelForTier(tierOpt)}" />
-                                </h:selectOneMenu>
-                                <div class="row row-cols-1 row-cols-sm-2 g-3">
-                                    <ui:repeat value="#{purchaseView.tiersForCitizen}" var="tierOpt">
+                            <h:panelGroup id="citizenshipChoices" layout="block">
+                                <div class="row row-cols-1 row-cols-md-3 g-3">
+                                    <ui:repeat value="#{purchaseView.citizenshipsForApp}" var="cit">
                                         <div class="col">
-                                            <div class="selectable-card h-100 #{purchaseView.isCitizenTierSelected(tierOpt) ? 'selected' : ''}">
-                                                <div class="card-body">
-                                                    <h3 class="h6 fw-semibold mb-1">#{purchaseView.labelForTier(tierOpt)}</h3>
-                                                    <p class="text-muted small mb-0">#{purchaseView.describeTierOption(tierOpt)}</p>
-                                                    <h:commandLink action="#{purchaseView.selectCitizenTier(tierOpt)}"
+                                            <div class="choice-card h-100 #{purchaseView.isCitizenshipSelected(cit) ? 'selected' : ''}">
+                                                <div class="card-body text-center">
+                                                    <span class="choice-card-icon" aria-hidden="true">
+                                                        <h:outputText value="#{purchaseView.iconForCitizenship(cit)}" />
+                                                    </span>
+                                                    <h3 class="h5 fw-semibold mb-2">#{purchaseView.labelForCitizenship(cit)}</h3>
+                                                    <p class="text-muted small mb-0">#{purchaseView.describeCitizenshipOption(cit)}</p>
+                                                    <h:commandLink action="#{purchaseView.selectCitizenship(cit)}"
                                                                   styleClass="stretched-link"
                                                                   value=""
-                                                                  title="Choose #{purchaseView.labelForTier(tierOpt)}">
+                                                                  title="Choose #{purchaseView.labelForCitizenship(cit)}">
                                                         <f:ajax execute="@this"
-                                                                render="purchaseForm:tier purchaseForm:variantSection purchaseForm:variant purchaseForm:totalCard purchaseForm:reviewButton purchaseForm:messages" />
+                                                                render="purchaseForm:citizenship purchaseForm:citizenshipChoices purchaseForm:tierSection purchaseForm:variantSection purchaseForm:variantChoices purchaseForm:variantSummary purchaseForm:addToCartButton purchaseForm:messages" />
                                                     </h:commandLink>
                                                 </div>
                                             </div>
                                         </div>
                                     </ui:repeat>
                                 </div>
-                                <h:message for="tier" styleClass="text-danger small mt-2 d-block" />
-                            </div>
+                            </h:panelGroup>
+                            <h:message for="citizenship" styleClass="text-danger small mt-2 d-block" />
                         </div>
-                    </h:panelGroup>
+                    </div>
 
-                    <h:panelGroup id="variantSection" layout="block" rendered="#{not empty purchaseView.variants}">
-                        <div class="card shadow-sm">
-                            <div class="card-body">
-                                <h2 class="h5 fw-semibold mb-3">Step 3 · Pick a replacement package</h2>
-                                <p class="text-muted mb-4">Every replacement package issues masked PINs and respects the delivery preferences you set below.</p>
-                                <h:selectOneMenu id="variant"
-                                                 value="#{purchaseView.selectedSku}"
-                                                 styleClass="d-none">
-                                    <f:selectItems value="#{purchaseView.variants}"
-                                                   var="variant"
-                                                   itemValue="#{variant.sku}"
-                                                   itemLabel="#{variant.displayName}" />
-                                </h:selectOneMenu>
-                                <div class="row row-cols-1 row-cols-md-2 g-3">
-                                    <ui:repeat value="#{purchaseView.variants}" var="variant">
-                                        <div class="col">
-                                            <div class="product-card h-100 #{purchaseView.isSkuSelected(variant.sku) ? 'selected' : ''}">
-                                                <div class="card-body d-flex flex-column gap-2">
-                                                    <div>
-                                                        <span class="badge bg-primary-subtle text-primary-emphasis mb-2">#{purchaseView.labelForCitizenship(variant.citizenship)}</span>
-                                                        <h3 class="h6 fw-semibold mb-1">#{variant.displayName}</h3>
-                                                        <p class="text-muted small mb-0">#{purchaseView.describeVariant(variant)}</p>
-                                                    </div>
-                                                    <div class="mt-auto">
-                                                        <p class="fw-semibold fs-5 mb-2">#{purchaseView.formatPrice(variant.price())}</p>
-                                                        <h:commandLink action="#{purchaseView.selectSku(variant.sku)}"
-                                                                      styleClass="btn btn-outline-primary w-100"
-                                                                      value="#{purchaseView.isSkuSelected(variant.sku) ? 'Selected' : 'Choose package'}">
-                                                            <f:ajax execute="@this"
-                                                                    render="purchaseForm:variant purchaseForm:variantSection purchaseForm:totalCard purchaseForm:reviewButton" />
-                                                        </h:commandLink>
+                    <h:panelGroup id="tierSection" layout="block">
+                        <h:panelGroup layout="block" rendered="#{purchaseView.isTierRequired()}">
+                            <div class="product-detail-card">
+                                <div class="card-body">
+                                    <h2 class="h4 fw-semibold mb-3">Step 2 · Select service tier</h2>
+                                    <p class="text-muted mb-4">Citizen replacements support both Standard and Premium service levels.</p>
+                                    <h:selectOneMenu id="tier"
+                                                     value="#{purchaseView.citizenTier}"
+                                                     styleClass="d-none"
+                                                     rendered="#{purchaseView.isTierRequired()}">
+                                        <f:selectItem itemLabel="" itemValue="" noSelectionOption="true" />
+                                        <f:selectItems value="#{purchaseView.tiersForCitizen}"
+                                                       var="tierOpt"
+                                                       itemValue="#{tierOpt}"
+                                                       itemLabel="#{purchaseView.labelForTier(tierOpt)}" />
+                                    </h:selectOneMenu>
+                                    <div class="row row-cols-1 row-cols-md-2 g-3">
+                                        <ui:repeat value="#{purchaseView.tiersForCitizen}" var="tierOpt">
+                                            <div class="col">
+                                                <div class="tier-card h-100 #{purchaseView.isCitizenTierSelected(tierOpt) ? 'selected' : ''}">
+                                                    <div class="card-body">
+                                                        <div class="d-flex justify-content-between align-items-start mb-3">
+                                                            <div>
+                                                                <h3 class="h5 fw-semibold mb-1">#{purchaseView.labelForTier(tierOpt)}</h3>
+                                                                <p class="text-muted small mb-0">#{purchaseView.describeTierOption(tierOpt)}</p>
+                                                            </div>
+                                                            <span class="price-tag">#{purchaseView.tierPriceLabel(tierOpt)}</span>
+                                                        </div>
+                                                        <div class="shimmer-hover">
+                                                            <h:commandLink action="#{purchaseView.selectCitizenTier(tierOpt)}"
+                                                                          styleClass="btn btn-dark btn-lg w-100 rounded-4"
+                                                                          value="#{purchaseView.isCitizenTierSelected(tierOpt) ? 'Selected' : 'Select'}">
+                                                                <f:ajax execute="@this"
+                                                                        render="purchaseForm:tier purchaseForm:variantSection purchaseForm:variantChoices purchaseForm:variantSummary purchaseForm:addToCartButton purchaseForm:messages" />
+                                                            </h:commandLink>
+                                                        </div>
                                                     </div>
                                                 </div>
                                             </div>
-                                        </div>
-                                    </ui:repeat>
+                                        </ui:repeat>
+                                    </div>
+                                    <h:message for="tier" styleClass="text-danger small mt-3 d-block" />
                                 </div>
-                                <h:message for="variant" styleClass="text-danger small mt-2 d-block" />
                             </div>
-                        </div>
+                        </h:panelGroup>
                     </h:panelGroup>
 
+                    <h:panelGroup id="variantSection" layout="block">
+                        <h:panelGroup id="variantSectionContent" layout="block" rendered="#{not empty purchaseView.variants}">
+                            <div class="product-detail-card">
+                                <div class="card-body">
+                                    <h2 class="h4 fw-semibold mb-3">Step 3 · Pick a replacement package</h2>
+                                    <p class="text-muted mb-4">Every package includes masked PINs delivered through the channels you’ll configure during checkout.</p>
+                                    <h:selectOneMenu id="variant"
+                                                     value="#{purchaseView.selectedSku}"
+                                                     styleClass="d-none">
+                                        <f:selectItems value="#{purchaseView.variants}"
+                                                       var="variant"
+                                                       itemValue="#{variant.sku}"
+                                                       itemLabel="#{variant.displayName}" />
+                                    </h:selectOneMenu>
+                                    <h:panelGroup id="variantChoices" layout="block">
+                                        <div class="row row-cols-1 row-cols-md-2 g-3">
+                                            <ui:repeat value="#{purchaseView.variants}" var="variant">
+                                                <div class="col">
+                                                    <div class="product-card h-100 #{purchaseView.isSkuSelected(variant.sku) ? 'selected' : ''}">
+                                                        <div class="card-body d-flex flex-column gap-3">
+                                                            <div>
+                                                                <span class="badge bg-primary-subtle text-primary-emphasis mb-2">#{purchaseView.labelForCitizenship(variant.citizenship)}</span>
+                                                                <h3 class="h5 fw-semibold mb-1">#{variant.displayName}</h3>
+                                                                <p class="text-muted small mb-0">#{purchaseView.describeVariant(variant)}</p>
+                                                            </div>
+                                                            <div class="mt-auto">
+                                                                <div class="d-flex justify-content-between align-items-center mb-3">
+                                                                    <span class="fw-semibold fs-5 mb-0">#{purchaseView.formatPrice(variant.price())}</span>
+                                                                </div>
+                                                                <h:commandLink action="#{purchaseView.selectSku(variant.sku)}"
+                                                                              styleClass="btn btn-outline-primary w-100"
+                                                                              value="#{purchaseView.isSkuSelected(variant.sku) ? 'Selected' : 'Choose package'}">
+                                                                    <f:ajax execute="@this"
+                                                                            render="purchaseForm:variant purchaseForm:variantChoices purchaseForm:variantSummary purchaseForm:addToCartButton purchaseForm:messages" />
+                                                                </h:commandLink>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </ui:repeat>
+                                        </div>
+                                    </h:panelGroup>
+                                    <h:panelGroup id="variantSummary" layout="block" rendered="#{purchaseView.hasSelectedSku()}">
+                                        <div class="variant-summary card mt-4">
+                                            <div class="card-body">
+                                                <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-4 mb-4">
+                                                    <div>
+                                                        <span class="badge bg-primary-subtle text-primary-emphasis mb-2">#{purchaseView.selectedSkuCitizenshipLabel()}</span>
+                                                        <h3 class="h4 fw-semibold mb-1">#{purchaseView.selectedSkuDisplayName()}</h3>
+                                                        <p class="text-muted mb-0">#{purchaseView.selectedSkuDescription()}</p>
+                                                    </div>
+                                                    <div class="text-lg-end">
+                                                        <div class="fs-3 fw-bold mb-1">#{purchaseView.unitPriceFormatted}</div>
+                                                        <span class="text-muted small text-uppercase">#{purchaseView.selectedSkuCurrencyCode()}</span>
+                                                    </div>
+                                                </div>
+                                                <dl class="row detail-grid small mb-0">
+                                                    <dt class="col-5 col-sm-4">Product code</dt>
+                                                    <dd class="col-7 col-sm-8">#{purchaseView.selectedSku}</dd>
+                                                    <dt class="col-5 col-sm-4">Subcategory</dt>
+                                                    <dd class="col-7 col-sm-8">#{purchaseView.selectedSkuSubcategoryLabel()}</dd>
+                                                    <dt class="col-5 col-sm-4">Status</dt>
+                                                    <dd class="col-7 col-sm-8">#{purchaseView.selectedSkuActiveLabel()}</dd>
+                                                    <dt class="col-5 col-sm-4">Duration</dt>
+                                                    <dd class="col-7 col-sm-8">#{purchaseView.selectedSkuDurationLabel()}</dd>
+                                                </dl>
+                                            </div>
+                                        </div>
+                                    </h:panelGroup>
+                                    <h:message for="variant" styleClass="text-danger small mt-3 d-block" />
+                                </div>
+                            </div>
+                        </h:panelGroup>
+                    </h:panelGroup>
+
+                    <p class="text-muted small">You can configure quantity, delivery channels, and payment during checkout.</p>
+
                     <div class="d-flex flex-column flex-sm-row gap-3">
-                        <h:panelGroup id="reviewButton" layout="block">
-                            <h:commandButton value="Review &amp; confirm"
-                                             action="#{purchaseView.submitEnrollment}"
-                                             styleClass="btn btn-primary btn-lg"
-                                             rendered="#{purchaseView.readyToAddToCart}" />
+                        <h:panelGroup id="addToCartButton" layout="block">
+                            <h:commandButton value="Add to cart"
+                                             action="#{purchaseView.addToCart}"
+                                             styleClass="btn btn-dark btn-lg rounded-4"
+                                             rendered="#{purchaseView.readyToAddToCart}">
+                                <f:ajax execute="@form"
+                                        render="purchaseForm:messages :cartToggle :cartDrawer" />
+                            </h:commandButton>
                         </h:panelGroup>
                         <h:link outcome="/index" styleClass="btn btn-outline-secondary btn-lg">Back to storefront</h:link>
                     </div>
                 </h:form>
-            </div>
-            <div class="col-12 col-xl-5 col-xxl-4">
-                <div class="position-sticky top-0">
-                    <h:panelGroup id="totalCard" layout="block" pt:aria-live="polite" pt:aria-atomic="true">
-                        <div class="card shadow-sm">
-                            <div class="card-body">
-                                <h2 class="h6 text-uppercase text-muted mb-3">Order summary</h2>
-                                <dl class="row mb-0 small">
-                                    <dt class="col-5">Variant</dt>
-                                    <dd class="col-7 fw-semibold">#{empty purchaseView.unitLabel ? 'Select a package' : purchaseView.unitLabel}</dd>
-                                    <dt class="col-5">Unit price</dt>
-                                    <dd class="col-7">#{empty purchaseView.unitPriceFormatted ? '—' : purchaseView.unitPriceFormatted}</dd>
-                                    <dt class="col-5">Quantity</dt>
-                                    <dd class="col-7">#{purchaseView.qty}</dd>
-                                    <dt class="col-5">Payment</dt>
-                                    <dd class="col-7">#{purchaseView.paymentModeTitle(purchaseView.mode)}</dd>
-                                    <dt class="col-5">Total</dt>
-                                    <dd class="col-7 fw-bold fs-5">#{empty purchaseView.totalFormatted ? '—' : purchaseView.totalFormatted}</dd>
-                                </dl>
-                            </div>
-                        </div>
-                    </h:panelGroup>
-                </div>
             </div>
         </div>
     </ui:define>


### PR DESCRIPTION
## Summary
- restyle the replacement purchase flow to match the first issuance layout and components
- add selection summary and add-to-cart action consistent with the other enrollment flows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2817e3b948330bf8332099f364d87