### PR TITLE
Add cart-wide checkout flow and summary page

### DIFF
--- a/src/main/java/com/theplutushome/veristore/view/CheckoutResultView.java
+++ b/src/main/java/com/theplutushome/veristore/view/CheckoutResultView.java
@@ -1,0 +1,261 @@
+package com.theplutushome.veristore.view;
+
+import com.theplutushome.veristore.domain.PaymentMode;
+import com.theplutushome.veristore.domain.Price;
+import com.theplutushome.veristore.service.OrderStore;
+import com.theplutushome.veristore.service.PricingService;
+import com.theplutushome.veristore.util.Masker;
+import com.theplutushome.veristore.util.VariantDescriptions;
+import com.theplutushome.veristore.view.CartView.CheckoutReference;
+import com.theplutushome.veristore.view.CartView.CheckoutResult;
+
+import jakarta.faces.application.FacesMessage;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Named
+@ViewScoped
+public class CheckoutResultView implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private CartView cartView;
+
+    @Inject
+    private OrderStore orderStore;
+
+    @Inject
+    private PricingService pricingService;
+
+    private final List<ResultLine> lines = new ArrayList<>();
+    private PaymentMode paymentMode;
+    private boolean missing;
+    private boolean loaded;
+
+    public void load() {
+        if (loaded) {
+            return;
+        }
+        loaded = true;
+        FacesContext context = FacesContext.getCurrentInstance();
+        if (context == null) {
+            missing = true;
+            return;
+        }
+        ExternalContext externalContext = context.getExternalContext();
+        Map<String, String> params = externalContext.getRequestParameterMap();
+        String token = Optional.ofNullable(params.get("token")).filter(s -> !s.isBlank()).orElse(null);
+        if (token == null) {
+            missing = true;
+            context.addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR, "Checkout session not found.", null));
+            return;
+        }
+        CheckoutResult result = cartView.consumeCheckoutResult(token);
+        if (result == null) {
+            missing = true;
+            context.addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR, "Checkout summary has expired.", null));
+            return;
+        }
+        paymentMode = result.getPaymentMode();
+        for (CheckoutReference reference : result.getReferences()) {
+            switch (reference.getType()) {
+                case ORDER -> orderStore.findOrder(reference.getReference()).ifPresent(order ->
+                        lines.add(ResultLine.fromOrder(order, pricingService)));
+                case INVOICE -> orderStore.findInvoice(reference.getReference()).ifPresent(invoice ->
+                        lines.add(ResultLine.fromInvoice(invoice, pricingService)));
+            }
+        }
+        if (lines.isEmpty()) {
+            missing = true;
+            context.addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR, "No checkout records could be found.", null));
+        }
+    }
+
+    public boolean isMissing() {
+        return missing;
+    }
+
+    public List<ResultLine> getLines() {
+        return lines;
+    }
+
+    public PaymentMode getPaymentMode() {
+        return paymentMode;
+    }
+
+    public boolean isPayNow() {
+        return paymentMode == PaymentMode.PAY_NOW;
+    }
+
+    public boolean isPayLater() {
+        return paymentMode == PaymentMode.PAY_LATER;
+    }
+
+    public String getHeading() {
+        if (isPayNow()) {
+            return "Checkout complete";
+        }
+        if (isPayLater()) {
+            return "Invoice generated";
+        }
+        return "Checkout summary";
+    }
+
+    public String getIntroText() {
+        if (isPayNow()) {
+            return "Your order is confirmed. Masked PINs appear below.";
+        }
+        if (isPayLater()) {
+            return "Share the invoice references below with your finance team to complete payment.";
+        }
+        return "Review the details from your checkout.";
+    }
+
+    public Map<String, String> getTotalsByCurrency() {
+        Map<String, Long> totals = new LinkedHashMap<>();
+        for (ResultLine line : lines) {
+            if (line.getCurrency() == null) {
+                continue;
+            }
+            totals.merge(line.getCurrency().name(), line.getTotalMinor(), Long::sum);
+        }
+        Map<String, String> formatted = new LinkedHashMap<>();
+        for (Map.Entry<String, Long> entry : totals.entrySet()) {
+            try {
+                Price price = new Price(com.theplutushome.veristore.domain.Currency.valueOf(entry.getKey()), entry.getValue());
+                formatted.put(entry.getKey(), pricingService.format(price));
+            } catch (IllegalArgumentException ex) {
+                // Ignore unknown currencies
+            }
+        }
+        return formatted;
+    }
+
+    public static final class ResultLine implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private final String reference;
+        private final String referenceLabel;
+        private final String service;
+        private final int quantity;
+        private final String totalFormatted;
+        private final com.theplutushome.veristore.domain.Currency currency;
+        private final long totalMinor;
+        private final List<String> maskedCodes;
+        private final String status;
+
+        private ResultLine(String reference,
+                            String referenceLabel,
+                            String service,
+                            int quantity,
+                            String totalFormatted,
+                            com.theplutushome.veristore.domain.Currency currency,
+                            long totalMinor,
+                            List<String> maskedCodes,
+                            String status) {
+            this.reference = reference;
+            this.referenceLabel = referenceLabel;
+            this.service = service;
+            this.quantity = quantity;
+            this.totalFormatted = totalFormatted;
+            this.currency = currency;
+            this.totalMinor = totalMinor;
+            this.maskedCodes = List.copyOf(maskedCodes);
+            this.status = status;
+        }
+
+        static ResultLine fromOrder(OrderStore.Order order, PricingService pricingService) {
+            String service = VariantDescriptions.describe(order.getKey().family(), order.getKey().sku());
+            String total = pricingService.format(new Price(order.getCurrency(), order.getTotalMinor()));
+            List<String> masked = order.getCodes().stream().map(Masker::mask).toList();
+            return new ResultLine(order.getId(),
+                    "Order",
+                    service,
+                    order.getQty(),
+                    total,
+                    order.getCurrency(),
+                    order.getTotalMinor(),
+                    masked,
+                    null);
+        }
+
+        static ResultLine fromInvoice(OrderStore.Invoice invoice, PricingService pricingService) {
+            String service = VariantDescriptions.describe(invoice.getKey().family(), invoice.getKey().sku());
+            String total = pricingService.format(new Price(invoice.getCurrency(), invoice.getTotalMinor()));
+            List<String> masked = invoice.getCodesIfDelivered().stream().map(Masker::mask).toList();
+            String status = switch (invoice.getStatus()) {
+                case PENDING -> "Pending payment";
+                case PAID -> "Paid";
+                case CANCELLED -> "Cancelled";
+            };
+            return new ResultLine(invoice.getInvoiceNo(),
+                    "Invoice",
+                    service,
+                    invoice.getQty(),
+                    total,
+                    invoice.getCurrency(),
+                    invoice.getTotalMinor(),
+                    masked,
+                    status);
+        }
+
+        public String getReference() {
+            return reference;
+        }
+
+        public String getReferenceLabel() {
+            return referenceLabel;
+        }
+
+        public String getService() {
+            return service;
+        }
+
+        public int getQuantity() {
+            return quantity;
+        }
+
+        public String getTotalFormatted() {
+            return totalFormatted;
+        }
+
+        public com.theplutushome.veristore.domain.Currency getCurrency() {
+            return currency;
+        }
+
+        public long getTotalMinor() {
+            return totalMinor;
+        }
+
+        public List<String> getMaskedCodes() {
+            return maskedCodes;
+        }
+
+        public boolean hasMaskedCodes() {
+            return !maskedCodes.isEmpty();
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public boolean hasStatus() {
+            return status != null && !status.isBlank();
+        }
+    }
+}

--- a/src/main/webapp/WEB-INF/partials/navbar.xhtml
+++ b/src/main/webapp/WEB-INF/partials/navbar.xhtml
@@ -77,15 +77,29 @@
                                     <div class="d-flex justify-content-between align-items-start mb-2">
                                         <div>
                                             <h6 class="fw-semibold mb-1">#{line.name}</h6>
-                                            <p class="text-muted small mb-0">SKU #{line.sku} · Qty #{line.qty}</p>
+                                            <p class="text-muted small mb-1">SKU #{line.sku}</p>
+                                            <p class="text-muted small mb-0">Unit price #{line.priceFormatted}</p>
                                         </div>
-                                        <span class="fw-semibold">#{line.totalFormatted}</span>
+                                        <div class="text-end">
+                                            <span class="fw-semibold d-block">#{line.totalFormatted}</span>
+                                            <span class="text-muted small">Total</span>
+                                        </div>
                                     </div>
-                                    <p class="small text-muted mb-3">#{line.priceFormatted} per unit · #{cartView.paymentModeLabel(line.paymentMode)}</p>
+                                    <div class="d-flex align-items-center gap-2 mb-3">
+                                        <h:outputLabel for="qty" value="Qty" styleClass="small mb-0" />
+                                        <h:inputText id="qty"
+                                                     value="#{line.qty}"
+                                                     styleClass="form-control form-control-sm"
+                                                     pt:type="number"
+                                                     pt:min="1"
+                                                     pt:max="10" />
+                                        <h:commandButton value="Update"
+                                                         action="#{cartView.updateLineQuantity(line.sku, line.qty)}"
+                                                         styleClass="btn btn-outline-primary btn-sm">
+                                            <f:ajax execute="@parent" render=":cartToggle :cartDrawer" />
+                                        </h:commandButton>
+                                    </div>
                                     <div class="d-flex flex-wrap gap-2">
-                                        <h:commandButton value="#{cartView.checkoutButtonLabel(line.paymentMode)}"
-                                                         action="#{cartView.goToCheckout(line.sku)}"
-                                                         styleClass="btn btn-primary btn-sm" />
                                         <h:commandButton value="Remove"
                                                          action="#{cartView.removeLine(line.sku)}"
                                                          styleClass="btn btn-outline-secondary btn-sm">
@@ -104,6 +118,9 @@
                                 </div>
                             </ui:repeat>
                         </div>
+                        <h:commandButton value="Checkout all"
+                                         action="#{cartView.goToCheckout}"
+                                         styleClass="btn btn-primary w-100" />
                     </h:panelGroup>
                 </h:form>
             </div>

--- a/src/main/webapp/checkout-result.xhtml
+++ b/src/main/webapp/checkout-result.xhtml
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/WEB-INF/template.xhtml">
+    <f:metadata>
+        <f:viewAction action="#{checkoutResultView.load}" />
+    </f:metadata>
+    <ui:define name="title">Checkout summary – Veristore</ui:define>
+    <ui:define name="content">
+        <h:panelGroup rendered="#{checkoutResultView.missing}" layout="block" styleClass="text-center py-5">
+            <h1 class="h3 mb-3">Checkout summary not available</h1>
+            <p class="text-muted mb-4">We couldn't find details for this checkout. Start a new purchase from the storefront.</p>
+            <div class="d-flex flex-column flex-sm-row gap-2 justify-content-center">
+                <h:link outcome="/index" styleClass="btn btn-primary">Back to storefront</h:link>
+            </div>
+        </h:panelGroup>
+
+        <h:panelGroup rendered="#{not checkoutResultView.missing}" layout="block">
+            <section class="row justify-content-center" aria-labelledby="checkoutSummaryHeading">
+                <div class="col-12 col-lg-10 col-xl-8">
+                    <div class="card border-0 shadow-sm mb-4">
+                        <div class="card-body p-4 p-lg-5">
+                            <h1 id="checkoutSummaryHeading" class="h3 fw-bold mb-3">#{checkoutResultView.heading}</h1>
+                            <p class="text-muted mb-4">#{checkoutResultView.introText}</p>
+
+                            <ui:repeat value="#{checkoutResultView.lines}" var="line">
+                                <div class="border rounded-3 p-3 mb-3">
+                                    <div class="d-flex flex-column flex-md-row justify-content-between gap-3">
+                                        <div>
+                                            <p class="text-uppercase small text-muted mb-1">#{line.referenceLabel}</p>
+                                            <p class="fw-semibold mb-1">#{line.reference}</p>
+                                            <p class="text-muted small mb-1">#{line.service}</p>
+                                            <p class="text-muted small mb-0">Quantity: #{line.quantity}</p>
+                                            <h:panelGroup rendered="#{line.hasStatus()}" layout="block" styleClass="mt-2">
+                                                <span class="badge bg-light text-dark">#{line.status}</span>
+                                            </h:panelGroup>
+                                        </div>
+                                        <div class="text-md-end">
+                                            <p class="text-muted small mb-1">Total</p>
+                                            <p class="fw-bold fs-5 mb-0">#{line.totalFormatted}</p>
+                                        </div>
+                                    </div>
+                                    <h:panelGroup rendered="#{line.hasMaskedCodes()}" layout="block" styleClass="mt-3">
+                                        <p class="text-muted small mb-2">Masked PINs</p>
+                                        <div class="d-flex flex-wrap gap-2">
+                                            <ui:repeat value="#{line.maskedCodes}" var="code">
+                                                <span class="badge bg-light text-dark">#{code}</span>
+                                            </ui:repeat>
+                                        </div>
+                                    </h:panelGroup>
+                                </div>
+                            </ui:repeat>
+
+                            <h:panelGroup layout="block" styleClass="mt-4">
+                                <h2 class="h6 text-uppercase text-muted mb-3">Totals</h2>
+                                <ui:repeat value="#{checkoutResultView.totalsByCurrency.entrySet()}" var="total">
+                                    <div class="d-flex justify-content-between small">
+                                        <span class="text-muted">#{total.key}</span>
+                                        <span class="fw-semibold">#{total.value}</span>
+                                    </div>
+                                </ui:repeat>
+                            </h:panelGroup>
+
+                            <div class="d-flex flex-column flex-sm-row gap-2 mt-4">
+                                <h:link outcome="/history" styleClass="btn btn-outline-primary flex-fill">View order history</h:link>
+                                <h:link outcome="/index" styleClass="btn btn-primary flex-fill">Back to storefront</h:link>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </h:panelGroup>
+    </ui:define>
+</ui:composition>

--- a/src/main/webapp/checkout.xhtml
+++ b/src/main/webapp/checkout.xhtml
@@ -11,41 +11,52 @@
     <ui:define name="title">Checkout – Veristore</ui:define>
     <ui:define name="content">
         <h:panelGroup rendered="#{checkoutView.missing}" layout="block" styleClass="text-center py-5">
-            <h1 class="h3 mb-3">Cart item not found</h1>
-            <p class="text-muted mb-4">The selection you tried to checkout is no longer in your cart. Add it again from the storefront.</p>
+            <h1 class="h3 mb-3">Your cart is empty</h1>
+            <p class="text-muted mb-4">Add items to your cart before proceeding to checkout.</p>
             <div class="d-flex flex-column flex-sm-row gap-2 justify-content-center">
                 <h:link outcome="/index" styleClass="btn btn-primary">Back to storefront</h:link>
             </div>
         </h:panelGroup>
 
         <h:panelGroup rendered="#{not checkoutView.missing}" layout="block">
-            <div class="row g-5 align-items-start">
-                <div class="col-12 col-xl-7 col-xxl-8">
-                    <h:form id="checkoutForm" styleClass="d-flex flex-column gap-4">
-                        <h:messages id="messages"
-                                    globalOnly="true"
-                                    styleClass="alert alert-warning"
-                                    rendered="#{not empty facesContext.messageList}"
-                                    errorClass="alert-danger"
-                                    infoClass="alert-info" />
+            <h1 class="h3 fw-bold mb-4">Review and checkout</h1>
+            <h:form id="checkoutForm" styleClass="d-flex flex-column gap-4">
+                <h:messages id="messages"
+                            globalOnly="true"
+                            styleClass="alert alert-warning"
+                            rendered="#{not empty facesContext.messageList}"
+                            errorClass="alert-danger"
+                            infoClass="alert-info" />
 
+                <div class="row g-4 align-items-start">
+                    <div class="col-12 col-xl-7 col-xxl-8">
+                        <div class="card shadow-sm h-100">
+                            <div class="card-body">
+                                <h2 class="h5 fw-semibold mb-4">Items in your cart</h2>
+                                <ui:repeat value="#{checkoutView.lines}" var="line" varStatus="status">
+                                    <div class="d-flex flex-column flex-sm-row justify-content-between gap-3 pb-3 #{status.last ? '' : 'mb-3 border-bottom'}">
+                                        <div class="flex-fill">
+                                            <h3 class="h6 fw-semibold mb-1">#{line.name}</h3>
+                                            <p class="text-muted small mb-1">SKU #{line.sku}</p>
+                                            <p class="text-muted small mb-0">Quantity: #{line.qty}</p>
+                                        </div>
+                                        <div class="text-sm-end">
+                                            <p class="text-muted small mb-1">Unit price</p>
+                                            <p class="fw-semibold mb-2">#{line.priceFormatted}</p>
+                                            <p class="text-muted small mb-1">Line total</p>
+                                            <p class="fw-bold fs-6 mb-0">#{line.totalFormatted}</p>
+                                        </div>
+                                    </div>
+                                </ui:repeat>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12 col-xl-5 col-xxl-4 d-flex flex-column gap-4">
                         <div class="card shadow-sm">
                             <div class="card-body">
-                                <h2 class="h5 fw-semibold mb-4">Delivery preferences</h2>
+                                <h2 class="h5 fw-semibold mb-4">Delivery &amp; payment options</h2>
                                 <div class="row g-3">
-                                    <div class="col-12 col-sm-6">
-                                        <label for="checkoutForm:quantity" class="form-label">Quantity</label>
-                                        <h:inputText id="quantity"
-                                                     value="#{checkoutView.qty}"
-                                                     styleClass="form-control"
-                                                     pt:type="number"
-                                                     pt:min="1"
-                                                     pt:max="10">
-                                            <f:ajax render="checkoutForm:summary" />
-                                        </h:inputText>
-                                        <h:message for="quantity" styleClass="text-danger small mt-1 d-block" />
-                                    </div>
-                                    <div class="col-12 col-sm-6">
+                                    <div class="col-12">
                                         <span class="form-label d-block">Payment option</span>
                                         <h:selectOneRadio id="paymentMode"
                                                           value="#{checkoutView.paymentMode}"
@@ -56,7 +67,7 @@
                                                            itemValue="#{modeOpt}" />
                                         </h:selectOneRadio>
                                         <h:panelGroup id="paymentModeChoices" layout="block">
-                                            <div class="row row-cols-1 row-cols-sm-2 g-3">
+                                            <div class="row row-cols-1 g-3">
                                                 <ui:repeat value="#{checkoutView.paymentModes}" var="modeOpt">
                                                     <div class="col">
                                                         <div class="selectable-card h-100 #{checkoutView.isPaymentModeSelected(modeOpt) ? 'selected' : ''}">
@@ -98,7 +109,7 @@
                                         </h:panelGroup>
                                         <h:message for="deliveryOptions" styleClass="text-danger small mt-1 d-block" />
                                     </div>
-                                    <div class="col-12 col-md-6">
+                                    <div class="col-12">
                                         <label for="checkoutForm:email" class="form-label">Email address</label>
                                         <h:inputText id="email"
                                                      value="#{checkoutView.email}"
@@ -109,7 +120,7 @@
                                         </h:inputText>
                                         <h:message id="emailMessage" for="email" styleClass="text-danger small mt-1 d-block" />
                                     </div>
-                                    <div class="col-12 col-md-6">
+                                    <div class="col-12">
                                         <label for="checkoutForm:msisdn" class="form-label">Phone number</label>
                                         <h:inputText id="msisdn"
                                                      value="#{checkoutView.msisdn}"
@@ -123,44 +134,54 @@
                             </div>
                         </div>
 
-                        <div class="d-flex flex-column flex-sm-row gap-3">
-                            <h:commandButton value="#{checkoutView.submitLabel}"
-                                             action="#{checkoutView.submit}"
-                                             styleClass="btn btn-primary btn-lg" />
-                            <h:commandLink action="#{checkoutView.cancel}"
-                                           styleClass="btn btn-outline-secondary btn-lg"
-                                           value="Back to storefront" />
-                        </div>
-                    </h:form>
-                </div>
-                <div class="col-12 col-xl-5 col-xxl-4">
-                    <div class="position-sticky top-0">
                         <h:panelGroup id="summary" layout="block" pt:aria-live="polite" pt:aria-atomic="true">
                             <div class="card shadow-sm">
                                 <div class="card-body">
                                     <h2 class="h6 text-uppercase text-muted mb-3">Order summary</h2>
-                                    <dl class="row mb-0 small">
-                                        <dt class="col-5">Product</dt>
-                                        <dd class="col-7 fw-semibold">#{checkoutView.line.name}</dd>
-                                        <dt class="col-5">SKU</dt>
-                                        <dd class="col-7">#{checkoutView.line.sku}</dd>
-                                        <dt class="col-5">Unit price</dt>
-                                        <dd class="col-7">#{checkoutView.unitPriceFormatted}</dd>
-                                        <dt class="col-5">Quantity</dt>
-                                        <dd class="col-7">#{checkoutView.qty}</dd>
-                                        <dt class="col-5">Payment</dt>
-                                        <dd class="col-7">#{checkoutView.paymentModeTitle(checkoutView.paymentMode)}</dd>
-                                        <dt class="col-5">Delivery</dt>
-                                        <dd class="col-7">#{checkoutView.deliverySummary}</dd>
-                                        <dt class="col-5">Total</dt>
-                                        <dd class="col-7 fw-bold fs-5">#{checkoutView.totalPriceFormatted}</dd>
-                                    </dl>
+                                    <p class="d-flex justify-content-between small mb-2">
+                                        <span class="text-muted">Items</span>
+                                        <span class="fw-semibold">#{checkoutView.itemCount}</span>
+                                    </p>
+                                    <ui:repeat value="#{checkoutView.totalsByCurrency.entrySet()}" var="total">
+                                        <p class="d-flex justify-content-between small mb-1">
+                                            <span class="text-muted">Total (#{total.key})</span>
+                                            <span class="fw-semibold">#{total.value}</span>
+                                        </p>
+                                    </ui:repeat>
+                                    <p class="d-flex justify-content-between small mb-1">
+                                        <span class="text-muted">Payment</span>
+                                        <span class="fw-semibold">#{checkoutView.paymentModeTitle(checkoutView.paymentMode)}</span>
+                                    </p>
+                                    <p class="d-flex justify-content-between small mb-1">
+                                        <span class="text-muted">Delivery</span>
+                                        <span class="fw-semibold">#{checkoutView.deliverySummary}</span>
+                                    </p>
+                                    <p class="d-flex justify-content-between small mb-0">
+                                        <span class="text-muted">Contact</span>
+                                        <span class="fw-semibold text-end">
+                                            <ui:fragment rendered="#{not empty checkoutView.email}">
+                                                #{checkoutView.email}
+                                                <ui:fragment rendered="#{not empty checkoutView.msisdn}"><br /></ui:fragment>
+                                            </ui:fragment>
+                                            <ui:fragment rendered="#{not empty checkoutView.msisdn}">#{checkoutView.msisdn}</ui:fragment>
+                                            <ui:fragment rendered="#{empty checkoutView.email and empty checkoutView.msisdn}">—</ui:fragment>
+                                        </span>
+                                    </p>
                                 </div>
                             </div>
                         </h:panelGroup>
+
+                        <div class="d-flex flex-column flex-sm-row gap-3">
+                            <h:commandButton value="#{checkoutView.submitLabel}"
+                                             action="#{checkoutView.submit}"
+                                             styleClass="btn btn-primary btn-lg flex-fill" />
+                            <h:commandLink action="#{checkoutView.cancel}"
+                                           styleClass="btn btn-outline-secondary btn-lg flex-fill"
+                                           value="Back to storefront" />
+                        </div>
                     </div>
                 </div>
-            </div>
+            </h:form>
         </h:panelGroup>
     </ui:define>
 </ui:composition>


### PR DESCRIPTION
## Summary
- enable quantity adjustments and a single checkout entry point directly from the cart drawer
- redesign the checkout form to review all cart items while configuring shared delivery and payment preferences
- add a checkout result view that lists generated order and invoice references after completing payment

## Testing
- mvn -q -DskipTests package *(fails: unable to download jakartaee BOM due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e29c3611c88330a2dbadd9d9c326d4