### PR TITLE
Create dedicated cart page for managing items

### DIFF
--- a/src/main/webapp/WEB-INF/partials/navbar.xhtml
+++ b/src/main/webapp/WEB-INF/partials/navbar.xhtml
@@ -36,12 +36,9 @@
                     </li>
                     <li class="nav-item ms-lg-3">
                         <h:panelGroup id="cartToggle" layout="block">
-                            <button class="btn btn-primary position-relative px-4 py-2 rounded-pill d-flex align-items-center gap-2"
-                                    type="button"
-                                    data-bs-toggle="offcanvas"
-                                    data-bs-target="#cartDrawerPanel"
-                                    aria-controls="cartDrawerPanel"
-                                    aria-label="View cart">
+                            <h:link outcome="/cart"
+                                    styleClass="btn btn-primary position-relative px-4 py-2 rounded-pill d-flex align-items-center gap-2"
+                                    pt:aria-label="View cart">
                                 <svg width="18" height="18" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
                                     <path d="M0 1.5A.5.5 0 0 1 .5 1H2a.5.5 0 0 1 .485.379L2.89 3H14.5a.5.5 0 0 1 .491.592l-1.5 8A.5.5 0 0 1 13 12H4a.5.5 0 0 1-.491-.408L2.01 3.607 1.61 2H.5a.5.5 0 0 1-.5-.5zM3.102 4l1.313 7h8.17l1.313-7H3.102zM5 12a2 2 0 1 0 0 4 2 2 0 0 0 0-4zm7 0a2 2 0 1 0 0 4 2 2 0 0 0 0-4zm-7 1a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm7 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
                                 </svg>
@@ -52,78 +49,11 @@
                                     #{cartView.itemCount}
                                     <span class="visually-hidden">items in cart</span>
                                 </h:panelGroup>
-                            </button>
+                            </h:link>
                         </h:panelGroup>
                     </li>
                 </ul>
             </div>
         </div>
     </nav>
-    <h:panelGroup id="cartDrawer" layout="block">
-        <div class="offcanvas offcanvas-end" tabindex="-1" id="cartDrawerPanel" aria-labelledby="cartDrawerLabel">
-            <div class="offcanvas-header">
-                <h5 class="offcanvas-title" id="cartDrawerLabel">Your cart</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
-            </div>
-            <div class="offcanvas-body">
-                <h:form id="cartForm" styleClass="d-flex flex-column gap-3">
-                    <h:panelGroup rendered="#{cartView.hasNoItems}" layout="block">
-                        <p class="text-muted mb-0">Your cart is empty. Add a package to begin checkout.</p>
-                    </h:panelGroup>
-                    <h:panelGroup rendered="#{not cartView.hasNoItems}" layout="block" styleClass="d-flex flex-column gap-3">
-                        <ui:repeat value="#{cartView.lines}" var="line">
-                            <div class="card shadow-sm">
-                                <div class="card-body">
-                                    <div class="d-flex justify-content-between align-items-start mb-2">
-                                        <div>
-                                            <h6 class="fw-semibold mb-1">#{line.name}</h6>
-                                            <p class="text-muted small mb-1">SKU #{line.sku}</p>
-                                            <p class="text-muted small mb-0">Unit price #{line.priceFormatted}</p>
-                                        </div>
-                                        <div class="text-end">
-                                            <span class="fw-semibold d-block">#{line.totalFormatted}</span>
-                                            <span class="text-muted small">Total</span>
-                                        </div>
-                                    </div>
-                                    <div class="d-flex align-items-center gap-2 mb-3">
-                                        <h:outputLabel for="qty" value="Qty" styleClass="small mb-0" />
-                                        <h:inputText id="qty"
-                                                     value="#{line.qty}"
-                                                     styleClass="form-control form-control-sm"
-                                                     pt:type="number"
-                                                     pt:min="1"
-                                                     pt:max="10" />
-                                        <h:commandButton value="Update"
-                                                         action="#{cartView.updateLineQuantity(line.sku, line.qty)}"
-                                                         styleClass="btn btn-outline-primary btn-sm">
-                                            <f:ajax execute="@parent" render=":cartToggle :cartDrawer" />
-                                        </h:commandButton>
-                                    </div>
-                                    <div class="d-flex flex-wrap gap-2">
-                                        <h:commandButton value="Remove"
-                                                         action="#{cartView.removeLine(line.sku)}"
-                                                         styleClass="btn btn-outline-secondary btn-sm">
-                                            <f:ajax render=":cartToggle :cartDrawer" />
-                                        </h:commandButton>
-                                    </div>
-                                </div>
-                            </div>
-                        </ui:repeat>
-                        <div class="border-top pt-3">
-                            <h6 class="fw-semibold mb-2">Totals</h6>
-                            <ui:repeat value="#{cartView.totalsByCurrency.entrySet()}" var="total">
-                                <div class="d-flex justify-content-between small">
-                                    <span class="text-muted">#{total.key}</span>
-                                    <span class="fw-semibold">#{total.value}</span>
-                                </div>
-                            </ui:repeat>
-                        </div>
-                        <h:commandButton value="Proceed to Checkout"
-                                         action="#{cartView.goToCheckout}"
-                                         styleClass="btn btn-primary w-100" />
-                    </h:panelGroup>
-                </h:form>
-            </div>
-        </div>
-    </h:panelGroup>
 </ui:composition>

--- a/src/main/webapp/buy-first-issuance.xhtml
+++ b/src/main/webapp/buy-first-issuance.xhtml
@@ -160,7 +160,7 @@
                                                                                  styleClass="btn btn-dark w-100"
                                                                                  style="position: relative; z-index: 2;">
                                                                     <f:ajax execute="@form"
-                                                                            render="purchaseForm:messages purchaseForm:variantChoices :cartToggle :cartDrawer" />
+                                                                            render="purchaseForm:messages purchaseForm:variantChoices :cartToggle" />
                                                                 </h:commandButton>
                                                             </div>
                                                             

--- a/src/main/webapp/buy-mobile-pins.xhtml
+++ b/src/main/webapp/buy-mobile-pins.xhtml
@@ -123,7 +123,7 @@
                                              action="#{pinPurchaseView.addToCart}"
                                              styleClass="btn btn-dark btn-lg rounded-4"
                                              rendered="#{pinPurchaseView.eligible}">
-                                <f:ajax execute="@form" render="pinForm:messages :cartToggle :cartDrawer" />
+                                <f:ajax execute="@form" render="pinForm:messages :cartToggle" />
                             </h:commandButton>
                         </h:panelGroup>
                         <h:link outcome="/index" styleClass="btn btn-outline-secondary btn-lg">Back to storefront</h:link>

--- a/src/main/webapp/buy-renewal.xhtml
+++ b/src/main/webapp/buy-renewal.xhtml
@@ -162,7 +162,7 @@
                                                                                  styleClass="btn btn-dark w-100"
                                                                                  style="position: relative; z-index: 2;">
                                                                     <f:ajax execute="@form"
-                                                                            render="purchaseForm:messages purchaseForm:variantChoices :cartToggle :cartDrawer" />
+                                                                            render="purchaseForm:messages purchaseForm:variantChoices :cartToggle" />
                                                                 </h:commandButton>
                                                             </div>
                                                             

--- a/src/main/webapp/buy-replacement.xhtml
+++ b/src/main/webapp/buy-replacement.xhtml
@@ -163,7 +163,7 @@
                                                                                  styleClass="btn btn-dark w-100"
                                                                                  style="position: relative; z-index: 2;">
                                                                     <f:ajax execute="@form"
-                                                                            render="purchaseForm:messages purchaseForm:variantChoices :cartToggle :cartDrawer" />
+                                                                            render="purchaseForm:messages purchaseForm:variantChoices :cartToggle" />
                                                                 </h:commandButton>
                                                             </div>
                                                             

--- a/src/main/webapp/buy-update.xhtml
+++ b/src/main/webapp/buy-update.xhtml
@@ -222,7 +222,7 @@
                                                                                  styleClass="btn btn-dark w-100"
                                                                                  style="position: relative; z-index: 2;">
                                                                     <f:ajax execute="@form"
-                                                                            render="purchaseForm:messages purchaseForm:variantChoices :cartToggle :cartDrawer" />
+                                                                            render="purchaseForm:messages purchaseForm:variantChoices :cartToggle" />
                                                                 </h:commandButton>
                                                             </div>
                                                             

--- a/src/main/webapp/buy-web-pins.xhtml
+++ b/src/main/webapp/buy-web-pins.xhtml
@@ -123,7 +123,7 @@
                                              action="#{pinPurchaseView.addToCart}"
                                              styleClass="btn btn-dark btn-lg rounded-4"
                                              rendered="#{pinPurchaseView.eligible}">
-                                <f:ajax execute="@form" render="pinForm:messages :cartToggle :cartDrawer" />
+                                <f:ajax execute="@form" render="pinForm:messages :cartToggle" />
                             </h:commandButton>
                         </h:panelGroup>
                         <h:link outcome="/index" styleClass="btn btn-outline-secondary btn-lg">Back to storefront</h:link>

--- a/src/main/webapp/cart.xhtml
+++ b/src/main/webapp/cart.xhtml
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:pt="http://xmlns.jcp.org/jsf/passthrough"
+                template="/WEB-INF/template.xhtml">
+    <ui:define name="title">Your cart – Veristore</ui:define>
+    <ui:define name="content">
+        <section class="mb-4" aria-labelledby="cartHeading">
+            <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3">
+                <div>
+                    <h1 id="cartHeading" class="display-6 fw-bold mb-1">Your cart</h1>
+                    <p class="text-muted mb-0">Review your selected PIN packages, adjust quantities, or remove items before checkout.</p>
+                </div>
+                <h:panelGroup layout="block" rendered="#{not cartView.hasNoItems}" styleClass="text-md-end">
+                    <span class="badge rounded-pill bg-primary-subtle text-primary fw-semibold px-3 py-2">
+                        #{cartView.itemCount} item#{cartView.itemCount eq 1 ? '' : 's'} in cart
+                    </span>
+                </h:panelGroup>
+            </div>
+        </section>
+
+        <h:form id="cartForm">
+            <h:panelGroup id="cartContent" layout="block" styleClass="d-flex flex-column gap-4">
+                <h:panelGroup rendered="#{cartView.hasNoItems}" layout="block">
+                    <div class="card border-0 shadow-sm">
+                        <div class="card-body p-5 text-center">
+                            <div class="display-6 text-primary mb-3">🛒</div>
+                            <h2 class="h4 fw-semibold mb-2">Your cart is empty</h2>
+                            <p class="text-muted mb-4">Browse our catalog to add identity services tailored to your organisation.</p>
+                            <h:link outcome="/index" styleClass="btn btn-primary px-4 py-2">Continue shopping</h:link>
+                        </div>
+                    </div>
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{not cartView.hasNoItems}" layout="block">
+                    <div class="row g-4 align-items-start">
+                        <div class="col-12 col-lg-8">
+                            <div class="d-flex flex-column gap-3">
+                                <ui:repeat value="#{cartView.lines}" var="line">
+                                    <div class="card border-0 shadow-sm h-100">
+                                        <div class="card-body p-4">
+                                            <div class="d-flex flex-column flex-md-row justify-content-between gap-3 mb-3">
+                                                <div>
+                                                    <h2 class="h5 fw-semibold mb-1">#{line.name}</h2>
+                                                    <p class="text-muted small mb-1">SKU #{line.sku}</p>
+                                                    <p class="text-muted small mb-0">Unit price #{line.priceFormatted}</p>
+                                                </div>
+                                                <div class="text-md-end">
+                                                    <span class="fw-semibold d-block fs-5">#{line.totalFormatted}</span>
+                                                    <span class="text-muted small">Line total</span>
+                                                </div>
+                                            </div>
+                                            <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-3">
+                                                <div class="d-flex align-items-center gap-2">
+                                                    <h:outputLabel for="qty" value="Quantity" styleClass="small fw-semibold text-muted mb-0" />
+                                                    <h:inputText id="qty"
+                                                                 value="#{line.qty}"
+                                                                 styleClass="form-control"
+                                                                 style="width: 5rem;"
+                                                                 pt:type="number"
+                                                                 pt:min="1"
+                                                                 pt:max="10"
+                                                                 pt:aria-label="Set quantity for #{line.name}" />
+                                                    <h:commandButton value="Update"
+                                                                     action="#{cartView.updateLineQuantity(line.sku, line.qty)}"
+                                                                     styleClass="btn btn-outline-primary">
+                                                        <f:ajax execute="@parent" render="cartForm:cartContent :cartToggle" />
+                                                    </h:commandButton>
+                                                </div>
+                                                <div class="ms-sm-auto">
+                                                    <h:commandButton value="Remove"
+                                                                     action="#{cartView.removeLine(line.sku)}"
+                                                                     styleClass="btn btn-outline-secondary"
+                                                                     pt:aria-label="Remove #{line.name} from cart">
+                                                        <f:ajax render="cartForm:cartContent :cartToggle" />
+                                                    </h:commandButton>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </ui:repeat>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-4">
+                            <aside class="card border-0 shadow-sm">
+                                <div class="card-body p-4">
+                                    <h2 class="h5 fw-semibold mb-3">Order summary</h2>
+                                    <ui:repeat value="#{cartView.totalsByCurrency.entrySet()}" var="total">
+                                        <div class="d-flex justify-content-between align-items-center py-2 border-bottom">
+                                            <span class="text-muted fw-medium">#{total.key}</span>
+                                            <span class="fw-semibold">#{total.value}</span>
+                                        </div>
+                                    </ui:repeat>
+                                    <p class="small text-muted mt-3">Totals reflect the combined amount due per currency.</p>
+                                    <div class="d-grid gap-2 mt-4">
+                                        <h:commandButton value="Proceed to checkout"
+                                                         action="#{cartView.goToCheckout}"
+                                                         styleClass="btn btn-primary btn-lg" />
+                                        <h:link outcome="/index" styleClass="btn btn-outline-secondary">Continue shopping</h:link>
+                                    </div>
+                                </div>
+                            </aside>
+                        </div>
+                    </div>
+                </h:panelGroup>
+            </h:panelGroup>
+        </h:form>
+    </ui:define>
+</ui:composition>


### PR DESCRIPTION
## Summary
- replace the navbar cart button with a link to a full cart page
- add a responsive cart management page with quantity updates, removal actions, and totals
- remove offcanvas drawer references from purchase flows now that the cart drawer is gone

## Testing
- mvn -q -DskipTests package *(fails: unable to download jakarta.jakartaee-bom due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e51b1cb4dc8330bb6fc0f3863be361