### PR TITLE
Enforce dual delivery during checkout

### DIFF
--- a/src/main/java/com/theplutushome/veristore/view/CheckoutView.java
+++ b/src/main/java/com/theplutushome/veristore/view/CheckoutView.java
@@ -56,8 +56,8 @@ public class CheckoutView implements Serializable {
         email = "";
         msisdn = "";
         paymentMode = PaymentMode.PAY_NOW;
-        deliverEmail = false;
-        deliverSms = false;
+        deliverEmail = true;
+        deliverSms = true;
     }
 
     public void load() {
@@ -73,8 +73,8 @@ public class CheckoutView implements Serializable {
         }
         CartLineDTO first = lines.get(0);
         paymentMode = Optional.ofNullable(first.getPaymentMode()).orElse(PaymentMode.PAY_NOW);
-        deliverEmail = lines.stream().anyMatch(CartLineDTO::isDeliverEmail);
-        deliverSms = lines.stream().anyMatch(CartLineDTO::isDeliverSms);
+        deliverEmail = true;
+        deliverSms = true;
         email = Optional.ofNullable(first.getEmail()).orElse("");
         msisdn = Optional.ofNullable(first.getMsisdn()).orElse("");
     }
@@ -226,27 +226,19 @@ public class CheckoutView implements Serializable {
             addMessage(null, FacesMessage.SEVERITY_ERROR, "Your cart is empty.");
             valid = false;
         }
-        if (!deliverEmail && !deliverSms) {
-            addMessage(componentId("deliveryOptions"), FacesMessage.SEVERITY_ERROR, "Choose at least one delivery channel.");
+        if (email == null || email.isBlank()) {
+            addMessage(componentId("email"), FacesMessage.SEVERITY_ERROR, "Enter an email address for delivery.");
+            valid = false;
+        } else if (!EMAIL_PATTERN.matcher(email).matches()) {
+            addMessage(componentId("email"), FacesMessage.SEVERITY_ERROR, "Enter a valid email address.");
             valid = false;
         }
-        if (deliverEmail) {
-            if (email == null || email.isBlank()) {
-                addMessage(componentId("email"), FacesMessage.SEVERITY_ERROR, "Enter an email address for delivery.");
-                valid = false;
-            } else if (!EMAIL_PATTERN.matcher(email).matches()) {
-                addMessage(componentId("email"), FacesMessage.SEVERITY_ERROR, "Enter a valid email address.");
-                valid = false;
-            }
-        }
-        if (deliverSms) {
-            if (msisdn == null || msisdn.isBlank()) {
-                addMessage(componentId("msisdn"), FacesMessage.SEVERITY_ERROR, "Enter a phone number including country code.");
-                valid = false;
-            } else if (!PHONE_PATTERN.matcher(msisdn).matches()) {
-                addMessage(componentId("msisdn"), FacesMessage.SEVERITY_ERROR, "Use international format starting with + and digits.");
-                valid = false;
-            }
+        if (msisdn == null || msisdn.isBlank()) {
+            addMessage(componentId("msisdn"), FacesMessage.SEVERITY_ERROR, "Enter a phone number including country code.");
+            valid = false;
+        } else if (!PHONE_PATTERN.matcher(msisdn).matches()) {
+            addMessage(componentId("msisdn"), FacesMessage.SEVERITY_ERROR, "Use international format starting with + and digits.");
+            valid = false;
         }
         if (!valid) {
             FacesContext context = FacesContext.getCurrentInstance();

--- a/src/main/webapp/checkout.xhtml
+++ b/src/main/webapp/checkout.xhtml
@@ -89,32 +89,16 @@
                                     </div>
                                     <div class="col-12">
                                         <span class="form-label d-block">Delivery channels</span>
-                                        <h:panelGroup id="deliveryOptions" layout="block" styleClass="d-flex flex-wrap gap-3">
-                                            <div class="form-check form-switch">
-                                                <h:selectBooleanCheckbox id="emailDelivery"
-                                                                         value="#{checkoutView.deliverEmail}"
-                                                                         styleClass="form-check-input">
-                                                    <f:ajax render="checkoutForm:summary checkoutForm:email checkoutForm:emailMessage" />
-                                                </h:selectBooleanCheckbox>
-                                                <label class="form-check-label" for="checkoutForm:emailDelivery">Email delivery</label>
-                                            </div>
-                                            <div class="form-check form-switch">
-                                                <h:selectBooleanCheckbox id="smsDelivery"
-                                                                         value="#{checkoutView.deliverSms}"
-                                                                         styleClass="form-check-input">
-                                                    <f:ajax render="checkoutForm:summary checkoutForm:msisdn checkoutForm:msisdnMessage" />
-                                                </h:selectBooleanCheckbox>
-                                                <label class="form-check-label" for="checkoutForm:smsDelivery">SMS delivery</label>
-                                            </div>
-                                        </h:panelGroup>
-                                        <h:message for="deliveryOptions" styleClass="text-danger small mt-1 d-block" />
+                                        <p class="text-muted small mb-0">PINs will be delivered via both email and SMS.</p>
                                     </div>
                                     <div class="col-12">
                                         <label for="checkoutForm:email" class="form-label">Email address</label>
                                         <h:inputText id="email"
                                                      value="#{checkoutView.email}"
                                                      styleClass="form-control"
+                                                     required="true"
                                                      pt:type="email"
+                                                     pt:required="true"
                                                      pt:placeholder="name@example.com">
                                             <f:ajax render="checkoutForm:summary" />
                                         </h:inputText>
@@ -125,6 +109,8 @@
                                         <h:inputText id="msisdn"
                                                      value="#{checkoutView.msisdn}"
                                                      styleClass="form-control"
+                                                     required="true"
+                                                     pt:required="true"
                                                      pt:placeholder="+233XXXXXXXXX">
                                             <f:ajax render="checkoutForm:summary" />
                                         </h:inputText>


### PR DESCRIPTION
## Summary
- default checkout processing to always deliver items via both email and SMS
- remove delivery channel toggles and require contact fields on the checkout form
- ensure server-side validation always checks email and phone inputs

## Testing
- mvn -q test *(fails: Unable to download jakarta.jakartaee-bom from Maven Central – HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e51daf14048330aa20f60844c54b3f